### PR TITLE
Exception handling

### DIFF
--- a/src/Skynet.Server.Shared/Database/DatabaseContext.cs
+++ b/src/Skynet.Server.Shared/Database/DatabaseContext.cs
@@ -29,6 +29,7 @@ namespace Skynet.Server.Database
             account.Property(a => a.AccountId).ValueGeneratedNever();
             account.Property(a => a.KeyHash).IsRequired();
             account.Property(a => a.CreationTime).HasDefaultValueSql("CURRENT_TIMESTAMP(6)");
+            account.Property(a => a.DeletionTime).IsConcurrencyToken();
 
             var session = modelBuilder.Entity<Session>();
             session.HasKey(s => s.SessionId);

--- a/src/Skynet.Server/Network/Client.cs
+++ b/src/Skynet.Server/Network/Client.cs
@@ -131,7 +131,7 @@ namespace Skynet.Server.Network
 
         private async Task Listen()
         {
-            connections.IncrementCounter();
+            connections.ClientConnected();
 
             while (true)
             {
@@ -195,7 +195,7 @@ namespace Skynet.Server.Network
                 }
             }
 
-            connections.DecrementCounter();
+            connections.ClientDisconnected();
         }
 
         private async ValueTask HandlePacket(byte id, PoolableMemory content)

--- a/src/Skynet.Server/Network/Client.cs
+++ b/src/Skynet.Server/Network/Client.cs
@@ -120,8 +120,8 @@ namespace Skynet.Server.Network
                 {
                     using IServiceScope scope = serviceProvider.CreateScope();
                     var clientState = scope.ServiceProvider.GetRequiredService<ClientStateService>();
-                    _ = await clientState.SetChannelAction(this, default, ChannelAction.None).ConfigureAwait(false);
-                    _ = await clientState.SetActive(this, false).ConfigureAwait(false);
+                    await clientState.StartSetChannelAction(this, default, ChannelAction.None).ConfigureAwait(false);
+                    if (Active != false) await clientState.StartSetActive(this, false).ConfigureAwait(false);
                 }
 
                 await sendQueue.DisposeAsync().ConfigureAwait(false);

--- a/src/Skynet.Server/Network/Handlers/P06CreateSessionHandler.cs
+++ b/src/Skynet.Server/Network/Handlers/P06CreateSessionHandler.cs
@@ -66,8 +66,8 @@ namespace Skynet.Server.Network.Handlers
             response.WebToken = session.WebToken;
             await Client.Send(response).ConfigureAwait(false);
 
-            _ = await Delivery.SyncChannels(Client, new List<long>(), lastMessageId: default).ConfigureAwait(false);
-            _ = await Delivery.SendMessage(deviceList, null).ConfigureAwait(false);
+            await Delivery.StartSyncChannels(Client, new List<long>(), lastMessageId: default).ConfigureAwait(false);
+            await Delivery.StartSendMessage(deviceList, null).ConfigureAwait(false);
 
             IClient old = connections.Add(Client);
             if (old != null)

--- a/src/Skynet.Server/Network/Handlers/P06CreateSessionHandler.cs
+++ b/src/Skynet.Server/Network/Handlers/P06CreateSessionHandler.cs
@@ -72,7 +72,7 @@ namespace Skynet.Server.Network.Handlers
             IClient old = connections.Add(Client);
             if (old != null)
             {
-                _ = old.DisposeAsync(unregister: false, true, false);
+                _ = old.DisposeAsync(unregister: false);
             }
         }
     }

--- a/src/Skynet.Server/Network/Handlers/P08RestoreSessionHandler.cs
+++ b/src/Skynet.Server/Network/Handlers/P08RestoreSessionHandler.cs
@@ -44,7 +44,7 @@ namespace Skynet.Server.Network.Handlers
             IClient old = connections.Add(Client);
             if (old != null)
             {
-                _ = old.DisposeAsync(unregister: false, true, false);
+                _ = old.DisposeAsync(unregister: false);
             }
         }
     }

--- a/src/Skynet.Server/Network/Handlers/P08RestoreSessionHandler.cs
+++ b/src/Skynet.Server/Network/Handlers/P08RestoreSessionHandler.cs
@@ -39,7 +39,7 @@ namespace Skynet.Server.Network.Handlers
             response.StatusCode = RestoreSessionStatus.Success;
             await Client.Send(response).ConfigureAwait(false);
 
-            _ = await Delivery.SyncChannels(Client, packet.Channels, packet.LastMessageId).ConfigureAwait(false);
+            await Delivery.StartSyncChannels(Client, packet.Channels, packet.LastMessageId).ConfigureAwait(false);
 
             IClient old = connections.Add(Client);
             if (old != null)

--- a/src/Skynet.Server/Network/Handlers/P0ERequestMessagesHandler.cs
+++ b/src/Skynet.Server/Network/Handlers/P0ERequestMessagesHandler.cs
@@ -7,11 +7,10 @@ namespace Skynet.Server.Network.Handlers
 {
     internal sealed class P0ERequestMessagesHandler : PacketHandler<P0ERequestMessages>
     {
-        public override ValueTask Handle(P0ERequestMessages packet)
+        public override async ValueTask Handle(P0ERequestMessages packet)
         {
-            _ = Delivery.SyncMessages(Client, packet.ChannelId, packet.After, packet.Before, packet.MaxCount);
+            await Delivery.StartSyncMessages(Client, packet.ChannelId, packet.After, packet.Before, packet.MaxCount).ConfigureAwait(false);
             _ = Client.Enqueue(Packets.New<P0FSyncFinished>());
-            return default;
         }
     }
 }

--- a/src/Skynet.Server/Network/Handlers/P18PublicKeysHandler.cs
+++ b/src/Skynet.Server/Network/Handlers/P18PublicKeysHandler.cs
@@ -59,7 +59,7 @@ namespace Skynet.Server.Network.Handlers
 
                 var directChannelUpdate = await injector
                     .CreateDirectChannelUpdate(channel.ChannelId, Client.AccountId, message.MessageId, bobId, bobPublicId).ConfigureAwait(false);
-                _ = await Delivery.SendMessage(directChannelUpdate, null).ConfigureAwait(false);
+                await Delivery.StartSendMessage(directChannelUpdate, null).ConfigureAwait(false);
             }
         }
     }

--- a/src/Skynet.Server/Network/Handlers/P34SetClientStateHandler.cs
+++ b/src/Skynet.Server/Network/Handlers/P34SetClientStateHandler.cs
@@ -21,9 +21,13 @@ namespace Skynet.Server.Network.Handlers
             if (packet.ChannelId == default && packet.Action != ChannelAction.None)
                 throw new ProtocolException("A ChannelAction other than None requires a ChannelId.");
 
-            // TODO: Make sure that all clients have received their P0ACreateChannel before sending this packet
-            _ = await clientState.SetChannelAction(Client, packet.ChannelId, packet.Action).ConfigureAwait(false);
-            _ = await clientState.SetActive(Client, packet.OnlineState == OnlineState.Active).ConfigureAwait(false);
+            await clientState.StartSetChannelAction(Client, packet.ChannelId, packet.Action).ConfigureAwait(false);
+
+            bool active = packet.OnlineState == OnlineState.Active;
+            if (Client.Active != active)
+            {
+                await clientState.StartSetActive(Client, active).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/Skynet.Server/Network/IClient.cs
+++ b/src/Skynet.Server/Network/IClient.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Skynet.Server.Network
 {
-    internal interface IClient : IAsyncDisposable
+    internal interface IClient
     {
         string ApplicationIdentifier { get; }
         int VersionCode { get; }
@@ -25,6 +25,6 @@ namespace Skynet.Server.Network
         Task Enqueue(Packet packet);
         Task Enqueue(ChannelMessage message);
         Task Enqueue(IAsyncEnumerable<ChannelMessage> messages);
-        ValueTask DisposeAsync(bool unregister, bool waitForHandling, bool updateState);
+        ValueTask DisposeAsync(bool unregister = true, bool waitForHandling = true, bool updateState = true);
     }
 }

--- a/src/Skynet.Server/Network/MessageHandler.cs
+++ b/src/Skynet.Server/Network/MessageHandler.cs
@@ -80,9 +80,9 @@ namespace Skynet.Server.Network
             packet.DispatchTime = DateTime.SpecifyKind(entity.DispatchTime, DateTimeKind.Local);
 
             if (packet.Id == 0x20)
-                _ = await Delivery.SendPriorityMessage(entity, exclude: Client, excludeFcmAccountId: Client.AccountId).ConfigureAwait(false);
+                await Delivery.StartSendPriorityMessage(entity, exclude: Client, excludeFcmAccountId: Client.AccountId).ConfigureAwait(false);
             else
-                _ = await Delivery.SendMessage(entity, exclude: Client).ConfigureAwait(false);
+                await Delivery.StartSendMessage(entity, exclude: Client).ConfigureAwait(false);
 
             await PostHandling(packet, entity).ConfigureAwait(false);
         }

--- a/src/Skynet.Server/Services/ListenerService.cs
+++ b/src/Skynet.Server/Services/ListenerService.cs
@@ -73,7 +73,7 @@ namespace Skynet.Server.Services
             listener.Dispose();
 
             Stopwatch stopwatch = Stopwatch.StartNew();
-            await connections.WaitAll().ConfigureAwait(false);
+            await connections.WaitDisconnectAll().ConfigureAwait(false);
             stopwatch.Stop();
 
             logger.LogInformation("All clients disconnected after {0}ms", stopwatch.ElapsedMilliseconds);

--- a/src/Skynet.Server/Services/ListenerService.cs
+++ b/src/Skynet.Server/Services/ListenerService.cs
@@ -7,6 +7,7 @@ using Skynet.Server.Configuration;
 using Skynet.Server.Extensions;
 using Skynet.Server.Network;
 using System;
+using System.IO;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -98,6 +99,12 @@ namespace Skynet.Server.Services
             catch (AuthenticationException ex)
             {
                 logger.LogInformation(ex, "TLS authentication failed");
+                await sslStream.DisposeAsync().ConfigureAwait(false);
+                return;
+            }
+            catch (IOException ex)
+            {
+                logger.LogInformation(ex, "TLS authentication aborted");
                 await sslStream.DisposeAsync().ConfigureAwait(false);
                 return;
             }

--- a/src/Skynet.Server/Services/ListenerService.cs
+++ b/src/Skynet.Server/Services/ListenerService.cs
@@ -7,6 +7,7 @@ using Skynet.Server.Configuration;
 using Skynet.Server.Extensions;
 using Skynet.Server.Network;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Security;
@@ -22,20 +23,30 @@ namespace Skynet.Server.Services
     {
         private readonly IServiceProvider serviceProvider;
         private readonly IOptions<ListenerOptions> listenerOptions;
+        private readonly ConnectionsService connections;
         private readonly ILogger<ListenerService> logger;
         private readonly CancellationTokenSource cts;
 
         private readonly Socket listener;
         private readonly IPEndPoint endPoint;
+        private readonly SslServerAuthenticationOptions sslOptions;
         private readonly X509Certificate2 certificate;
 
-        public ListenerService(IServiceProvider serviceProvider, IOptions<ListenerOptions> listenerOptions, ILogger<ListenerService> logger)
+        public ListenerService(IServiceProvider serviceProvider, IOptions<ListenerOptions> listenerOptions,
+            ConnectionsService connections, ILogger<ListenerService> logger)
         {
             this.serviceProvider = serviceProvider;
             this.listenerOptions = listenerOptions;
+            this.connections = connections;
             this.logger = logger;
 
             certificate = new X509Certificate2(listenerOptions.Value.CertificatePath);
+            sslOptions = new SslServerAuthenticationOptions
+            {
+                ServerCertificate = certificate,
+                EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+            };
+
             endPoint = new IPEndPoint(IPAddress.IPv6Any, listenerOptions.Value.Port);
 
             listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp)
@@ -50,51 +61,56 @@ namespace Skynet.Server.Services
         {
             listener.Bind(endPoint);
             listener.Listen(listenerOptions.Value.Backlog);
-            LoopAsync().CatchExceptions(logger);
+            LoopAsync(cts.Token).CatchExceptions(logger);
             logger.LogInformation("Listening on {0}", endPoint);
 
             return Task.CompletedTask;
         }
 
-        public Task StopAsync(CancellationToken cancellationToken)
+        public async Task StopAsync(CancellationToken cancellationToken)
         {
             cts.Cancel();
             listener.Dispose();
-            return Task.CompletedTask;
+
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            await connections.WaitAll().ConfigureAwait(false);
+            stopwatch.Stop();
+
+            logger.LogInformation("All clients disconnected after {0}ms", stopwatch.ElapsedMilliseconds);
         }
 
-        private async Task LoopAsync()
+        private async Task LoopAsync(CancellationToken ct)
         {
             try
             {
                 while (true)
                 {
                     Socket client = await listener.AcceptAsync().ConfigureAwait(false);
-                    if (cts.IsCancellationRequested)
+                    if (ct.IsCancellationRequested)
                     {
                         client.Dispose();
                         break;
                     }
                     else
                     {
-                        AuthenticateAsync(client).CatchExceptions(logger);
+                        AuthenticateAsync(client, ct).CatchExceptions(logger);
                     }
                 }
             }
             catch (SocketException ex) when (ex.SocketErrorCode == SocketError.OperationAborted)
             {
                 // Server is shutting down
-                logger.LogInformation(ex, "Listener exited");
+                logger.LogInformation("Listener exited");
             }
         }
 
-        private async Task AuthenticateAsync(Socket socket)
+        private async Task AuthenticateAsync(Socket socket, CancellationToken ct)
         {
             NetworkStream networkStream = new NetworkStream(socket, ownsSocket: true);
             SslStream sslStream = new SslStream(networkStream, leaveInnerStreamOpen: false);
             try
             {
-                await sslStream.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls12 | SslProtocols.Tls13, false).ConfigureAwait(false);
+                await sslStream.AuthenticateAsServerAsync(sslOptions, ct).ConfigureAwait(false);
             }
             catch (AuthenticationException ex)
             {
@@ -109,14 +125,14 @@ namespace Skynet.Server.Services
                 return;
             }
 
-            if (cts.IsCancellationRequested)
+            if (ct.IsCancellationRequested)
             {
                 await sslStream.DisposeAsync().ConfigureAwait(false);
             }
             else
             {
                 PacketStream stream = new PacketStream(sslStream, leaveInnerStreamOpen: false);
-                _ = ActivatorUtilities.CreateInstance<Client>(serviceProvider, stream, cts.Token);
+                _ = ActivatorUtilities.CreateInstance<Client>(serviceProvider, stream, ct);
             }
         }
 

--- a/src/Skynet.Server/Services/NotificationService.cs
+++ b/src/Skynet.Server/Services/NotificationService.cs
@@ -80,7 +80,7 @@ namespace Skynet.Server.Services
                         await database.SaveChangesAsync().ConfigureAwait(false);
 
                         Message deviceList = await injector.CreateDeviceList(session.AccountId).ConfigureAwait(false);
-                        _ = await delivery.SendMessage(deviceList, null).ConfigureAwait(false);
+                        await delivery.StartSendMessage(deviceList, null).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/Skynet.Server/Utilities/StreamQueue.cs
+++ b/src/Skynet.Server/Utilities/StreamQueue.cs
@@ -57,7 +57,6 @@ namespace Skynet.Server.Utilities
                 }
                 else
                 {
-                    // TODO: Provide an API to pass a CancellationToken here
                     IAsyncEnumerator<TItem> enumerator = queueItem.Items.GetAsyncEnumerator();
                     bool next = await enumerator.MoveNextAsync().ConfigureAwait(false);
                     if (!next)

--- a/tests/Skynet.Server.Tests/Services/ConnectionsServiceTests.cs
+++ b/tests/Skynet.Server.Tests/Services/ConnectionsServiceTests.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skynet.Server.Network;
+using Skynet.Server.Services;
+using Skynet.Server.Tests.Fakes;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Skynet.Server.Tests.Services
+{
+    [TestClass]
+    public class ConnectionsServiceTests
+    {
+        [TestMethod]
+        public void TestReplaceOnDuplicate()
+        {
+            IClient client1 = new FakeClient { AccountId = 1, SessionId = 1 };
+            IClient client2 = new FakeClient { AccountId = 1, SessionId = 1 };
+            var connections = new ConnectionsService();
+
+            IClient replaced1 = connections.Add(client1);
+            Assert.IsNull(replaced1);
+
+            Assert.IsTrue(connections.TryGet(1, out IClient out1));
+            Assert.IsTrue(ReferenceEquals(client1, out1));
+
+            IClient replaced2 = connections.Add(client2);
+            Assert.IsTrue(ReferenceEquals(client1, replaced2));
+
+            Assert.IsTrue(connections.TryGet(1, out IClient out2));
+            Assert.IsTrue(ReferenceEquals(client2, out2));
+        }
+
+        [TestMethod]
+        public async Task TestWaitDisconnectEmpty()
+        {
+            var connections = new ConnectionsService();
+            connections.ClientConnected();
+            connections.ClientDisconnected();
+            await connections.WaitDisconnectAll().ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task TestWaitDisconnect()
+        {
+            var connections = new ConnectionsService();
+            connections.ClientConnected();
+            connections.ClientConnected();
+            connections.ClientDisconnected();
+            connections.ClientDisconnected();
+            connections.ClientConnected();
+            bool empty = false;
+            var task = connections.WaitDisconnectAll().ContinueWith(_ => Assert.IsTrue(empty), TaskScheduler.Default);
+            connections.ClientDisconnected();
+            empty = true;
+            await task.ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Skynet.Server.Tests/Services/DeliveryServiceTests.cs
+++ b/tests/Skynet.Server.Tests/Services/DeliveryServiceTests.cs
@@ -67,7 +67,7 @@ namespace Skynet.Server.Tests.Services
             var packet = packets.New<P0ACreateChannel>();
 
             Assert.IsTrue(connections.TryGet(1, out IClient exclude), "Client disappeared from ConnectionsService");
-            await delivery.SendToAccount(packet, alice, exclude).ConfigureAwait(false);
+            await delivery.StartSendToAccount(packet, alice, exclude).ConfigureAwait(false);
 
             Assert.IsFalse(sent[1]);
             Assert.IsFalse(sent[2]);
@@ -92,7 +92,7 @@ namespace Skynet.Server.Tests.Services
             var packet = packets.New<P0ACreateChannel>();
 
             Assert.IsTrue(connections.TryGet(1, out IClient exclude), "Client disappeared from ConnectionsService");
-            await delivery.SendToChannel(packet, 1, exclude).ConfigureAwait(false);
+            await delivery.StartSendToChannel(packet, 1, exclude).ConfigureAwait(false);
 
             Assert.IsFalse(sent[1]);
             Assert.IsFalse(sent[2]);


### PR DESCRIPTION
This pull request brings further improvements to thread safety and exception handling to resolve #32.
- The `Client` class does not follow the typical `IDisposable` pattern. Instead of throwing an `ObjectDisposedException` most methods simply turn to no-ops.
- Account deletion can no longer lead to dead locks
- The server now waits for all handling operations to finish before shutting down